### PR TITLE
bice: Support enum value as right operand

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -41,8 +41,12 @@ func validateLeftOperand(left *cc.Expr) error {
 }
 
 func validateRightOperand(right *cc.Expr) error {
-	if right.Op != cc.Number {
-		return fmt.Errorf("unexpected right operand: %s; must be a constant number", right)
+	if right.Op != cc.Number && right.Op != cc.Name {
+		return fmt.Errorf("expect constant number or enum as right operand, got %s", right.Text)
+	}
+
+	if right.Op == cc.Name {
+		return nil
 	}
 
 	if _, err := parseNumber(right.Text); err != nil {

--- a/validate_test.go
+++ b/validate_test.go
@@ -67,6 +67,7 @@ func TestValidateRightOperand(t *testing.T) {
 	}{
 		{name: "number", right: &cc.Expr{Op: cc.Number, Text: "0x1234"}, valid: true},
 		{name: "invalid number", right: &cc.Expr{Op: cc.Number, Text: "1234a"}, valid: false},
+		{name: "name", right: &cc.Expr{Op: cc.Name, Text: "skb"}, valid: true},
 		{name: "add", right: &cc.Expr{Op: cc.Add}, valid: false},
 	}
 


### PR DESCRIPTION
It is really useful to support enum value instead of the corresponding integer value as right operand.

For example, you should use `prog->type == BPF_PROG_TYPE_SOCKET_FILTER` instead of `prog->type == 1`.