### PR TITLE
bice: Support struct/union member access

### DIFF
--- a/access.go
+++ b/access.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright Leon Hwang */
+
+package bice
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+type AccessOptions struct {
+	Insns     asm.Instructions
+	Expr      string
+	Type      btf.Type
+	Src       asm.Register
+	Dst       asm.Register
+	LabelExit string
+}
+
+type AccessResult struct {
+	Insns     asm.Instructions
+	LabelUsed bool
+}
+
+func Access(opts AccessOptions) (AccessResult, error) {
+	if opts.Expr == "" || opts.Type == nil || opts.LabelExit == "" {
+		return AccessResult{}, fmt.Errorf("invalid options")
+	}
+
+	ast, err := parse(opts.Expr)
+	if err != nil {
+		return AccessResult{}, fmt.Errorf("failed to compile expression %s: %w", opts.Expr, err)
+	}
+
+	err = validateLeftOperand(ast)
+	if err != nil {
+		return AccessResult{}, fmt.Errorf("expression is not struct/union member access: %w", err)
+	}
+
+	offsets, err := expr2offset(ast, opts.Type)
+	if err != nil {
+		return AccessResult{}, fmt.Errorf("failed to convert expression to offsets: %w", err)
+	}
+
+	if len(offsets.offsets) == 0 {
+		return AccessResult{}, fmt.Errorf("expr should be struct/union member access")
+	}
+
+	size, err := checkLastField(offsets.member, offsets.lastField)
+	if err != nil {
+		return AccessResult{}, err
+	}
+
+	insns := opts.Insns
+	if opts.Src != asm.R3 {
+		insns = append(insns, asm.Mov.Reg(asm.R3, opts.Src))
+	}
+	insns, labelUsed := offset2insns(insns, offsets.offsets, opts.Dst, opts.LabelExit)
+
+	tgt := tgtInfo{0, offsets.lastField, size, offsets.bigEndian}
+	insns, _ = tgt2insns(insns, tgt, opts.Dst)
+
+	return AccessResult{
+		Insns:     insns,
+		LabelUsed: labelUsed,
+	}, nil
+}

--- a/access_test.go
+++ b/access_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+/* Copyright Leon Hwang */
+
+package bice
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/asm"
+	"github.com/leonhwangprojects/bice/internal/test"
+)
+
+func TestAccess(t *testing.T) {
+	t.Run("empty options", func(t *testing.T) {
+		_, err := Access(AccessOptions{})
+		test.AssertHaveErr(t, err)
+		test.AssertEqual(t, err.Error(), "invalid options")
+	})
+
+	t.Run("failed to parse", func(t *testing.T) {
+		_, err := Access(AccessOptions{
+			Expr:      "a)(test)",
+			Type:      getSkbBtf(t),
+			LabelExit: labelExitFail,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to compile expression")
+	})
+
+	t.Run("invalid left operand", func(t *testing.T) {
+		_, err := Access(AccessOptions{
+			Expr:      "a+b == c",
+			Type:      getSkbBtf(t),
+			LabelExit: labelExitFail,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "expression is not struct/union member access")
+	})
+
+	t.Run("failed to convert expression to offsets", func(t *testing.T) {
+		_, err := Access(AccessOptions{
+			Expr:      "skb->xxx",
+			Type:      getSkbBtf(t),
+			LabelExit: labelExitFail,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "failed to convert expression to offsets")
+	})
+
+	t.Run("empty offsets", func(t *testing.T) {
+		_, err := Access(AccessOptions{
+			Expr:      "skb",
+			Type:      getSkbBtf(t),
+			LabelExit: labelExitFail,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "expr should be struct/union member access")
+	})
+
+	t.Run("failed to check last field", func(t *testing.T) {
+		_, err := Access(AccessOptions{
+			Expr:      "skb->pkt_type",
+			Type:      getSkbBtf(t),
+			LabelExit: labelExitFail,
+		})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), "unexpected member access of bitfield")
+	})
+
+	t.Run("skb->len", func(t *testing.T) {
+		insns, err := Access(AccessOptions{
+			Expr:      "skb->len",
+			Type:      getSkbBtf(t),
+			Src:       asm.R1,
+			Dst:       asm.R3,
+			Insns:     nil,
+			LabelExit: labelExitFail,
+		})
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, insns.Insns, asm.Instructions{
+			asm.Mov.Reg(asm.R3, asm.R1),
+			asm.Add.Imm(asm.R3, 112),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.R10),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R3, asm.RFP, -8, asm.DWord),
+			asm.LSh.Imm(asm.R3, 32),
+			asm.RSh.Imm(asm.R3, 32),
+		})
+		test.AssertEqual(t, insns.LabelUsed, false)
+	})
+}

--- a/simple_test.go
+++ b/simple_test.go
@@ -4,7 +4,6 @@
 package bice
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -33,7 +32,7 @@ func TestSimpleCompile(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		insns, err := SimpleCompile("skb->len > 1024", getSkbBtf(t))
 		test.AssertNoErr(t, err)
-		test.AssertEqualSlice(t, insns, skbLen1024Insns)
+		test.AssertEqualSlice(t, insns, cloneSkbLen1024InsnsWithoutExitLabel())
 	})
 }
 
@@ -56,7 +55,7 @@ func TestSimpleInjectFilter(t *testing.T) {
 
 	t.Run("inject", func(t *testing.T) {
 		prog := prepareProgSpec()
-		insns := slices.Clone(skbLen1024Insns)
+		insns := cloneSkbLen1024InsnsWithoutExitLabel()
 		insns[0] = insns[0].WithMetadata(prog.Instructions[4].Metadata)
 
 		err := SimpleInjectFilter(InjectOptions{


### PR DESCRIPTION
This commit aims to generate bpf insns for struct/union member access, e.g. `skb->head`, `xdp->data`, `xdp->data_end` and so on.