### PR TITLE
simple: The btf type must be a pointer

### DIFF
--- a/simple.go
+++ b/simple.go
@@ -6,6 +6,7 @@ package bice
 import (
 	"fmt"
 
+	"github.com/Asphaltt/mybtf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 )
@@ -69,6 +70,10 @@ import (
 // The operator must be one of the following: =, ==, !=, <, <=, >, >=. '=' is
 // used for comparison too.
 func SimpleCompile(expr string, typ btf.Type) (asm.Instructions, error) {
+	if _, isPtr := mybtf.UnderlyingType(typ).(*btf.Pointer); !isPtr {
+		return nil, fmt.Errorf("type(%s) is not a pointer", typ)
+	}
+
 	ast, err := parse(expr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse expression(%s): %w", expr, err)

--- a/simple_test.go
+++ b/simple_test.go
@@ -4,15 +4,23 @@
 package bice
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/leonhwangprojects/bice/internal/test"
 )
 
 func TestSimpleCompile(t *testing.T) {
+	t.Run("non-pointer type", func(t *testing.T) {
+		_, err := SimpleCompile("skb->len > 1024", &btf.Int{})
+		test.AssertHaveErr(t, err)
+		test.AssertStrPrefix(t, err.Error(), fmt.Sprintf("type(%s) is not a pointer", &btf.Int{}))
+	})
+
 	t.Run("failed to parse", func(t *testing.T) {
-		_, err := SimpleCompile("a)(test)", nil)
+		_, err := SimpleCompile("a)(test)", getSkbBtf(t))
 		test.AssertHaveErr(t, err)
 		test.AssertStrPrefix(t, err.Error(), "failed to parse expression")
 	})


### PR DESCRIPTION
As simple compiling requires `skb->hash` alike struct/union member access by pointer, the btf type for `SimpleCompile()` must be `*btf.Pointer`.