### PR TITLE
compile: Fix compiling skb != 0

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -372,12 +372,12 @@ func compile(expr *cc.Expr, typ btf.Type) (asm.Instructions, error) {
 		return nil, fmt.Errorf("failed to convert operator to instructions: %w", err)
 	}
 
+	xorR0 := asm.Xor.Reg(asm.R0, asm.R0)
 	if labelUsed {
-		insns = append(insns,
-			asm.Mov.Imm(asm.R0, 0).WithSymbol(labelExitFail), // r0 = 0; __exit
-		)
+		xorR0 = xorR0.WithSymbol(labelExitFail)
 	}
 	insns = append(insns,
+		xorR0,                                // r0 = 0
 		asm.Return().WithSymbol(labelReturn), // return; __return
 	)
 

--- a/simple.go
+++ b/simple.go
@@ -6,7 +6,6 @@ package bice
 import (
 	"fmt"
 
-	"github.com/Asphaltt/mybtf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 )
@@ -70,10 +69,6 @@ import (
 // The operator must be one of the following: =, ==, !=, <, <=, >, >=. '=' is
 // used for comparison too.
 func SimpleCompile(expr string, typ btf.Type) (asm.Instructions, error) {
-	if _, isPtr := mybtf.UnderlyingType(typ).(*btf.Pointer); !isPtr {
-		return nil, fmt.Errorf("type(%s) is not a pointer", typ)
-	}
-
 	ast, err := parse(expr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse expression(%s): %w", expr, err)

--- a/simple_test.go
+++ b/simple_test.go
@@ -4,23 +4,15 @@
 package bice
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/btf"
 	"github.com/leonhwangprojects/bice/internal/test"
 )
 
 func TestSimpleCompile(t *testing.T) {
-	t.Run("non-pointer type", func(t *testing.T) {
-		_, err := SimpleCompile("skb->len > 1024", &btf.Int{})
-		test.AssertHaveErr(t, err)
-		test.AssertStrPrefix(t, err.Error(), fmt.Sprintf("type(%s) is not a pointer", &btf.Int{}))
-	})
-
 	t.Run("failed to parse", func(t *testing.T) {
-		_, err := SimpleCompile("a)(test)", getSkbBtf(t))
+		_, err := SimpleCompile("a)(test)", nil)
 		test.AssertHaveErr(t, err)
 		test.AssertStrPrefix(t, err.Error(), "failed to parse expression")
 	})


### PR DESCRIPTION
If there is no struct/union member access, the zeroing R0 insn is
missing.

So, add the missing `xor r0, r0`, then add label when necessary.