### PR TITLE
bice: Support filter/access bitfield attribute

### DIFF
--- a/access.go
+++ b/access.go
@@ -69,7 +69,11 @@ func Access(opts AccessOptions) (AccessResult, error) {
 	insns, labelUsed := offset2insns(insns, offsets.offsets, opts.Dst, opts.LabelExit, isArr)
 
 	tgt := tgtInfo{0, offsets.lastField, size, offsets.bigEndian}
-	insns, _ = tgt2insns(insns, tgt, opts.Dst)
+	if IsMemberBitfield(offsets.member) {
+		insns, _ = bitfield2insns(insns, tgt.constant, offsets.member, asm.R3)
+	} else {
+		insns, _ = tgt2insns(insns, tgt, asm.R3)
+	}
 
 	return AccessResult{
 		Insns:     insns,


### PR DESCRIPTION
In kernel, there are many many bitfield attributes in struct or union.

In order to improve bice's usability, it's really necessary to support filter and access bitfield attributes.

For filtering them:

1. Mask the right operand's constant.
2. Read the bitfield attribute with 8 bytes.
3. Right-shift the register if necessary.
4. Compare them.

For accessing them:

1. Read the bitfield attribute with 8 bytes.
2. Right-shift the register if necessary.
3. The register holds the bitfield attribute without right-shift.