### PR TITLE
access: Fix using custom dst reg

### DIFF
--- a/access.go
+++ b/access.go
@@ -70,9 +70,9 @@ func Access(opts AccessOptions) (AccessResult, error) {
 
 	tgt := tgtInfo{0, offsets.lastField, size, offsets.bigEndian}
 	if IsMemberBitfield(offsets.member) {
-		insns, _ = bitfield2insns(insns, tgt.constant, offsets.member, asm.R3)
+		insns, _ = bitfield2insns(insns, tgt.constant, offsets.member, opts.Dst)
 	} else {
-		insns, _ = tgt2insns(insns, tgt, asm.R3)
+		insns, _ = tgt2insns(insns, tgt, opts.Dst)
 	}
 
 	return AccessResult{

--- a/access_test.go
+++ b/access_test.go
@@ -155,4 +155,25 @@ func TestAccess(t *testing.T) {
 			asm.And.Imm(asm.R3, 0x7),
 		})
 	})
+
+	t.Run("skb->pkt_type and src r1 and dst r2", func(t *testing.T) {
+		res, err := Access(AccessOptions{
+			Expr:      "skb->pkt_type",
+			Type:      getSkbBtf(t),
+			Src:       asm.R1,
+			Dst:       asm.R2,
+			Insns:     nil,
+			LabelExit: labelExitFail,
+		})
+		test.AssertNoErr(t, err)
+		test.AssertEqualSlice(t, res.Insns, asm.Instructions{
+			asm.Mov.Reg(asm.R3, asm.R1),
+			asm.Mov.Imm(asm.R2, 8),
+			asm.Mov.Reg(asm.R1, asm.R10),
+			asm.Add.Imm(asm.R1, -8),
+			asm.FnProbeReadKernel.Call(),
+			asm.LoadMem(asm.R2, asm.RFP, -8, asm.DWord),
+			asm.And.Imm(asm.R2, 0x7),
+		})
+	})
 }


### PR DESCRIPTION
It's a code logic bug to use `R3` as dst reg always disgarding the dst reg in options.