### PR TITLE
endian_le: add LoongArch64 support

### DIFF
--- a/endian_le.go
+++ b/endian_le.go
@@ -1,5 +1,5 @@
-//go:build 386 || amd64 || arm || arm64 || mips64le || ppc64le || riscv64 || wasm
-// +build 386 amd64 arm arm64 mips64le ppc64le riscv64 wasm
+//go:build 386 || amd64 || arm || arm64 || mips64le || ppc64le || riscv64 || wasm || loong64
+// +build 386 amd64 arm arm64 mips64le ppc64le riscv64 wasm loong64
 
 // SPDX-License-Identifier: Apache-2.0
 /* Copyright Leon Hwang */


### PR DESCRIPTION
cilium pwru build error occurs on LoongArch64 in [0]

vendor/github.com/leonhwangprojects/bice/compile.go:242:22: undefined: h2ns
vendor/github.com/leonhwangprojects/bice/compile.go:251:22: undefined: h2nl
vendor/github.com/leonhwangprojects/bice/compile.go:261:15: undefined: h2nll

add loong64 in endian_le.go to avoid the build error.

[0]: https://github.com/cilium/pwru/issues/559